### PR TITLE
Use append-only circular buffer for LastGatherer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -280,12 +280,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.junit.vintage</groupId>
-            <artifactId>junit-vintage-engine</artifactId>
-            <version>${junit.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
             <version>${assertj.version}</version>


### PR DESCRIPTION
Use a custom-crafted append-only circular buffer implementation as backing the implementation of `LastGatherer` for the sake of better performance

<img width="1432" alt="Screenshot 2024-10-15 at 13 16 46" src="https://github.com/user-attachments/assets/29454d5e-b455-4b21-a92c-da6e2b0e8a92">
