### PR TITLE
Fix MoreGatherers.distinctByKeepLast iteration order

### DIFF
--- a/src/main/java/com/pivovarit/gatherers/DistinctByKeepLastGatherer.java
+++ b/src/main/java/com/pivovarit/gatherers/DistinctByKeepLastGatherer.java
@@ -22,7 +22,7 @@ record DistinctByKeepLastGatherer<T, U>(
     @Override
     public Integrator<LinkedHashMap<U, T>, T, T> integrator() {
         return Integrator.ofGreedy((state, element, _) -> {
-            state.put(keyExtractor.apply(element), element);
+            state.putLast(keyExtractor.apply(element), element);
             return true;
         });
     }
@@ -30,7 +30,7 @@ record DistinctByKeepLastGatherer<T, U>(
     @Override
     public BiConsumer<LinkedHashMap<U, T>, Downstream<? super T>> finisher() {
         return (state, downstream) -> {
-            for (T element : state.values()) {
+            for (T element : state.sequencedValues()) {
                 downstream.push(element);
             }
         };

--- a/src/test/java/com/pivovarit/gatherers/blackbox/DistinctByKeepLastTest.java
+++ b/src/test/java/com/pivovarit/gatherers/blackbox/DistinctByKeepLastTest.java
@@ -23,6 +23,13 @@ class DistinctByKeepLastTest {
     }
 
     @Test
+    void shouldDistinctByAndKeepLastOrder() {
+        assertThat(Stream.of("a", "bb", "ddd", "cc")
+          .gather(distinctByKeepLast(String::length)))
+          .containsExactly("a", "ddd", "cc");
+    }
+
+    @Test
     void shouldRejectNullExtractor() {
         assertThatThrownBy(() -> distinctByKeepLast(null)).isInstanceOf(NullPointerException.class);
     }


### PR DESCRIPTION
Relying on `LinkedHashMap#put` would cause undesired elements order, because `put` effectively replaces the previous value in the original iteration order.

```
Stream.of("a", "bb", "ddd", "cc")
  .gather(distinctByKeepLast(String::length))
```

would result in a sequence: ```"a", "cc", "ddd"``` instead of ```"a", "ddd", "cc"```